### PR TITLE
[DO NOT MERGE] Show link component

### DIFF
--- a/examples/links/index.js
+++ b/examples/links/index.js
@@ -32,6 +32,21 @@ function unwrapLink(change) {
   change.unwrapInline('link')
 }
 
+function LinkComponent(props) {
+  const linkStyle = {
+    backgroundColor: "lightblue",
+    textAlign: "center",
+    borderRadius: "10px",
+    width: "60%",
+    margin: "auto",
+  }
+  return <div style={linkStyle}>
+    <span>Link: {props.href}</span>
+    <div style={{width:"50%", margin:"auto",}}><input /></div>
+    <div>Submit</div>
+  </div>
+}
+
 /**
  * The links example.
  *
@@ -100,9 +115,14 @@ class Links extends React.Component {
         const { data } = node
         const href = data.get('href')
         return (
-          <a {...attributes} href={href}>
-            {children}
-          </a>
+          <div>
+            <div>
+            <a {...attributes} href={href}>
+              {children}
+            </a>
+            </div>
+            <LinkComponent href={href}/>
+          </div>
         )
       }
     }


### PR DESCRIPTION
This is to show how to create the desired component from data inside a node:
<img width="831" alt="screen shot 2018-09-21 at 11 35 40" src="https://user-images.githubusercontent.com/401047/45899744-8c35a180-bd92-11e8-8ca3-01d6fbac366b.png">


#### Is this adding or improving a _feature_ or fixing a _bug_?

<!-- 
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?

<!-- 
Please include at least one of the following: 

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?

<!-- 
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [ ] The new code matches the existing patterns and styles.
* [ ] The tests pass with `yarn test`.
* [ ] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [ ] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
